### PR TITLE
Feat/members

### DIFF
--- a/src/main/java/com/emotie/api/common/exception/DuplicatedException.java
+++ b/src/main/java/com/emotie/api/common/exception/DuplicatedException.java
@@ -1,0 +1,8 @@
+package com.emotie.api.common.exception;
+
+public class DuplicatedException extends RuntimeException {
+
+    public DuplicatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/emotie/api/common/exceptionHandler/CommonExceptionHandlers.java
+++ b/src/main/java/com/emotie/api/common/exceptionHandler/CommonExceptionHandlers.java
@@ -1,14 +1,12 @@
 package com.emotie.api.common.exceptionHandler;
 
 import com.emotie.api.auth.exception.*;
+import com.emotie.api.common.exception.DuplicatedException;
 import com.emotie.api.common.exception.NotSameException;
 import com.emotie.api.member.exception.CannotFollowException;
-import com.emotie.api.member.exception.DuplicatedMemberException;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -53,7 +51,7 @@ public class CommonExceptionHandlers {
     }
 
     @ExceptionHandler({
-            ExpiredTokenException.class, WrongTokenException.class, DuplicatedMemberException.class,
+            ExpiredTokenException.class, WrongTokenException.class, DuplicatedException.class,
             CannotFollowException.class
     })
     public ResponseEntity<Map<String, String>> conflictHandler(Exception e) {

--- a/src/main/java/com/emotie/api/member/controller/MemberController.java
+++ b/src/main/java/com/emotie/api/member/controller/MemberController.java
@@ -1,10 +1,7 @@
 package com.emotie.api.member.controller;
 
-import com.emotie.api.member.domain.Gender;
 import com.emotie.api.member.domain.Member;
-import com.emotie.api.member.dto.MemberCreateRequest;
-import com.emotie.api.member.dto.MemberFollowResponse;
-import com.emotie.api.member.dto.MemberUpdateRequest;
+import com.emotie.api.member.dto.*;
 import com.emotie.api.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -13,7 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.Arrays;
+import java.util.Map;
 
 @SuppressWarnings({"RedundantThrows", "unused"})
 @RestController
@@ -29,6 +26,12 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/nickname")
+    public ResponseEntity<Map<String, Boolean>> checkNicknameDuplicate(@RequestBody @Valid NicknameCheckRequest request) {
+        Boolean checkNicknameDuplicateFlag = memberService.checkNicknameUse(request.getNickname());
+        return ResponseEntity.ok().body(Map.of("checkNickname", checkNicknameDuplicateFlag));
+    }
+
     @PutMapping
     public ResponseEntity<Void> updateMemberInformation(
             @AuthenticationPrincipal Member user, @RequestBody @Valid MemberUpdateRequest request
@@ -36,6 +39,22 @@ public class MemberController {
         memberService.update(user, request);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/password")
+    public ResponseEntity<Map<String, Boolean>> checkPasswordRight(@AuthenticationPrincipal Member user,
+                                                                   @RequestBody @Valid PasswordCheckRequest request) {
+        Boolean checkPasswordRightFlag = memberService.checkPasswordRight(user, request);
+        return ResponseEntity.ok().body(Map.of("checkPassword", checkPasswordRightFlag));
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<Void> updateMemberPassword(
+            @AuthenticationPrincipal Member user, @RequestBody @Valid PasswordUpdateRequest request
+    ) throws Exception {
+        memberService.updatePassword(user, request);
+        return ResponseEntity.ok().build();
+    }
+
 
     @PostMapping(value = "/follow/{nickname}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<MemberFollowResponse> toggleMemberFollow(

--- a/src/main/java/com/emotie/api/member/domain/Member.java
+++ b/src/main/java/com/emotie/api/member/domain/Member.java
@@ -163,9 +163,10 @@ public class Member extends TimestampEntity implements UserDetails {
         this.passwordResetTokenValidUntil = LocalDateTime.now().plusDays(1L);
     }
 
+
     public void checkPasswordResetTokenAndUpdatePassword(String passwordResetToken, PasswordResetRequest request) {
         checkPasswordResetToken(passwordResetToken);
-        updatePassword(request);
+        updatePassword(request.getPassword());
     }
 
     public void checkAuthorized() {
@@ -187,8 +188,8 @@ public class Member extends TimestampEntity implements UserDetails {
     public boolean isFollowedBy(Member member) {
         return this.followers.contains(member);
     }
-
     // 사용자가 누군가를 팔로우한다는 것은
+
     public void follow(Member member) {
         // 사용자의 팔로이에 그 사람이 추가 되고
         this.followees.add(member);
@@ -237,14 +238,12 @@ public class Member extends TimestampEntity implements UserDetails {
         this.roles.changeRole(MemberRole.EXPELLED);
     }
 
-    private void updatePassword(PasswordResetRequest request) {
-        this.passwordHash = request.getPassword();
+    public void updatePassword(String updatePassword) {
+        this.passwordHash = updatePassword;
     }
 
-    public void updateUserInfo(
-            MemberUpdateRequest request, String passwordHash
-    ) {
-        this.passwordHash = passwordHash;
+    public void updateUserInfo(MemberUpdateRequest request) {
+        this.nickname = request.getNickname();
         this.gender = request.getGender();
         this.dateOfBirth = request.getDateOfBirth();
     }

--- a/src/main/java/com/emotie/api/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/emotie/api/member/dto/MemberUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.emotie.api.member.dto;
 
-import com.emotie.api.common.exception.NotSameException;
 import com.emotie.api.member.domain.Gender;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,11 +13,8 @@ import java.time.LocalDate;
 
 @Getter
 public class MemberUpdateRequest {
-    @NotBlank(message = "비밀번호를 입력해주세요.")
-    private final String password;
-
-    @NotBlank(message = "비밀번호 확인란에 입력해주세요.")
-    private final String passwordCheck;
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private final String nickname;
 
     @NotNull(message = "성별을 선택해주세요.")
     private final Gender gender;
@@ -30,20 +26,12 @@ public class MemberUpdateRequest {
     @JsonCreator
     @Builder
     public MemberUpdateRequest(
-            @JsonProperty(value = "password", required = true) String password,
-            @JsonProperty(value = "passwordCheck", required = true) String passwordCheck,
+            @JsonProperty(value = "nickname", required = true) String nickname,
             @JsonProperty(value = "gender", required = true) Gender gender,
             @JsonProperty(value = "dateOfBirth", required = true) LocalDate dateOfBirth
     ) {
-        this.password = password;
-        this.passwordCheck = passwordCheck;
+        this.nickname = nickname;
         this.gender = gender;
         this.dateOfBirth = dateOfBirth;
-    }
-
-    public void checkPasswordMatches() {
-        if (!this.password.equals(this.passwordCheck)) {
-            throw new NotSameException("비밀번호와 비밀번호 확인 문자열이 다릅니다.");
-        }
     }
 }

--- a/src/main/java/com/emotie/api/member/dto/NicknameCheckRequest.java
+++ b/src/main/java/com/emotie/api/member/dto/NicknameCheckRequest.java
@@ -1,0 +1,22 @@
+package com.emotie.api.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+public class NicknameCheckRequest {
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(message = "닉네임은 32글자보다 짧고, 적어도 1글자 이상이어야 합니다.", max = 32)
+    private final String nickname;
+
+    @JsonCreator
+    @Builder
+    public NicknameCheckRequest(@JsonProperty(value = "nickname", required = true) String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/emotie/api/member/dto/PasswordCheckRequest.java
+++ b/src/main/java/com/emotie/api/member/dto/PasswordCheckRequest.java
@@ -1,0 +1,20 @@
+package com.emotie.api.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class PasswordCheckRequest {
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    @JsonCreator
+    @Builder
+    public PasswordCheckRequest(@JsonProperty(value = "password", required = true) String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/emotie/api/member/dto/PasswordUpdateRequest.java
+++ b/src/main/java/com/emotie/api/member/dto/PasswordUpdateRequest.java
@@ -1,0 +1,34 @@
+package com.emotie.api.member.dto;
+
+import com.emotie.api.common.exception.NotSameException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class PasswordUpdateRequest {
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private final String password;
+
+    @NotBlank(message = "비밀번호 확인란에 입력해주세요.")
+    private final String passwordCheck;
+
+    @JsonCreator
+    @Builder
+    public PasswordUpdateRequest(
+            @JsonProperty(value = "password", required = true) String password,
+            @JsonProperty(value = "passwordCheck", required = true) String passwordCheck
+    ) {
+        this.password = password;
+        this.passwordCheck = passwordCheck;
+    }
+
+    public void checkPasswordMatches() {
+        if (!this.password.equals(this.passwordCheck)) {
+            throw new NotSameException("비밀번호와 비밀번호 확인 문자열이 다릅니다.");
+        }
+    }
+}

--- a/src/main/java/com/emotie/api/member/exception/DuplicatedMemberException.java
+++ b/src/main/java/com/emotie/api/member/exception/DuplicatedMemberException.java
@@ -1,8 +1,0 @@
-package com.emotie.api.member.exception;
-
-public class DuplicatedMemberException extends RuntimeException{
-
-    public DuplicatedMemberException(String message) {
-        super(message);
-    }
-}

--- a/src/test/java/com/emotie/api/member/MemberAcceptanceTest.java
+++ b/src/test/java/com/emotie/api/member/MemberAcceptanceTest.java
@@ -180,7 +180,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     public void 회원가입_실패_CONFLICT_1() throws Exception {
         // given
         MemberCreateRequest request = MemberCreateRequest.builder()
-                .nickname(MemberDataLoader.authorizedEmail)
+                .nickname(authorizedNickname)
                 .password(createTestPassword)
                 .passwordCheck(createTestPassword)
                 .gender(Gender.HIDDEN)

--- a/src/test/java/com/emotie/api/member/MemberAcceptanceTest.java
+++ b/src/test/java/com/emotie/api/member/MemberAcceptanceTest.java
@@ -4,17 +4,12 @@ import com.emotie.api.AcceptanceTest;
 import com.emotie.api.auth.dto.LoginRequest;
 import com.emotie.api.auth.dto.LoginResponse;
 import com.emotie.api.member.domain.Gender;
-import com.emotie.api.member.dto.MemberCreateRequest;
-import com.emotie.api.member.dto.MemberFollowResponse;
-import com.emotie.api.member.dto.MemberUpdateRequest;
+import com.emotie.api.member.dto.*;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
@@ -23,14 +18,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.emotie.api.auth.AuthAcceptanceTest.*;
+import static com.emotie.api.member.MemberDataLoader.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @SuppressWarnings({"NonAsciiCharacters", "RedundantThrows", "CommentedOutCode"})
 @ActiveProfiles("memberDataLoader")
-@TestMethodOrder(MethodOrderer.DisplayName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @RequiredArgsConstructor
-public class MemberApiTest extends AcceptanceTest {
+public class MemberAcceptanceTest extends AcceptanceTest {
     // TODO: 2021-08-13 가입과 수정에 관한 모든 경우에 대하여, password, nickname 의 형식이 필요할 것으로 보임.
 
 //    // 나중에 실제 구현할 때 추가해야할 테스트 코드
@@ -43,24 +39,24 @@ public class MemberApiTest extends AcceptanceTest {
     /*
         회원가입 테스트를 위한 상수
      */
-    private static final String
+    private final String
             createTestEmail = "randomhuman@gmail.com",
             createTestPassword = "creative!password",
             changedPassword = "better_password?",
             notExistNickname = "공릉동익룡";
 
-//    @BeforeEach
+    //    @BeforeEach
 //    public void settingRepositories() {
 //        memberRepository.deleteAll();
 //        followeesRepository.deleteAll();
 //        followersRepository.deleteAll();
 //    }
-
     /*
         회원가입 테스트
      */
     @Test
-    @DisplayName("테스트 01: 회원가입 실패 [400]; 정보가 하나 이상 누락 됨.")
+    @Order(1)
+    @DisplayName("회원가입 실패 [400]; 정보가 하나 이상 누락 됨.")
     public void 회원가입_실패_BAD_REQUEST_1() throws Exception {
         // 회원가입_실패_필요_정보_누락 이 더 좋은 테스트 메소드명 아닌가?
         // given
@@ -80,7 +76,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 02: 회원가입 실패 [400]; 잘못된 생년월일 형식")
+    @Order(2)
+    @DisplayName("회원가입 실패 [400]; 잘못된 생년월일 형식")
     public void 회원가입_실패_BAD_REQUEST_2() throws Exception {
         // given
         MemberCreateRequest request = MemberCreateRequest.builder()
@@ -100,7 +97,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 03: 회원가입 실패 [400]; 선택할 수 없는 성별 값(잘못된 형식)")
+    @Order(3)
+    @DisplayName("회원가입 실패 [400]; 선택할 수 없는 성별 값(잘못된 형식)")
     public void 회원가입_실패_BAD_REQUEST_3() throws Exception {
         // given
         MemberCreateRequest request = MemberCreateRequest.builder()
@@ -141,7 +139,8 @@ public class MemberApiTest extends AcceptanceTest {
 //    }
 
     @Test
-    @DisplayName("테스트 05: 회원 가입 실패 [400]; 비밀번호가 비밀번호 확인 문자열과 다름")
+    @Order(5)
+    @DisplayName("회원 가입 실패 [400]; 비밀번호가 비밀번호 확인 문자열과 다름")
     public void 회원가입_실패_BAD_REQUEST_5() throws Exception {
         MemberCreateRequest request = MemberCreateRequest.builder()
                 .nickname(createTestEmail)
@@ -160,7 +159,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 06: 회원 가입 실패 [400]; 잘못된 형식의 Req")
+    @Order(6)
+    @DisplayName("회원 가입 실패 [400]; 잘못된 형식의 Req")
     public void 회원가입_실패_BAD_REQUEST_6() throws Exception {
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
@@ -175,7 +175,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 06: 회원가입 실패 [409]; 이미 사용 중인 닉네임으로 닉네임 설정")
+    @Order(7)
+    @DisplayName("회원가입 실패 [409]; 이미 사용 중인 닉네임으로 닉네임 설정")
     public void 회원가입_실패_CONFLICT_1() throws Exception {
         // given
         MemberCreateRequest request = MemberCreateRequest.builder()
@@ -195,7 +196,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 07: 회원가입 실패 [409]; 이미 사용 중인 이메일로 이메일 설정")
+    @Order(8)
+    @DisplayName("회원가입 실패 [409]; 이미 사용 중인 이메일로 이메일 설정")
     public void 회원가입_실패_CONFLICT_2() throws Exception {
         // given
         MemberCreateRequest request = MemberCreateRequest.builder()
@@ -215,7 +217,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 08: 회원가입 성공 [200]")
+    @Order(9)
+    @DisplayName("회원가입 성공 [200]")
     public void 회원가입_성공_OK() throws Exception {
         // given
         MemberCreateRequest request = MemberCreateRequest.builder()
@@ -238,18 +241,72 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     /*
-        회원 정보 수정 테스트
+        닉네임 중복 확인
      */
     @Test
-    @DisplayName("테스트 09: 회원 정보 수정 실패 [400]; 선택할 수 없는 성별 값(잘못된 형식)")
-    public void 회원정보_수정_실패_BAD_REQUEST_1() throws Exception {
+    @Order(10)
+    @DisplayName("닉네임 중복 확인 실패 [400]; 닉네임 값이 없을 때")
+    public void 닉네임_중복_확인_실패_BAD_REQUEST() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        NicknameCheckRequest request = NicknameCheckRequest.builder().build();
+
+        //when
+        ExtractableResponse<Response> response = checkNicknameDuplicateRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("닉네임 중복 확인 성공; 중복한 닉네임이 없을 때 checkNickname true [200]")
+    public void 닉네임_중복_확인_성공_OK_1() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        NicknameCheckRequest request = NicknameCheckRequest.builder()
+                .nickname(notExistNickname)
+                .build();
+
+        //when
+        ExtractableResponse<Response> response = checkNicknameDuplicateRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body().jsonPath().getBoolean("checkNickname")).isEqualTo(true);
+    }
+
+    @Test
+    @Order(12)
+    @DisplayName("닉네임 중복 확인 성공; 중복한 닉네임이 있을 때 checkNickname false [200]")
+    public void 닉네임_중복_확인_성공_OK_2() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        NicknameCheckRequest request = NicknameCheckRequest.builder()
+                .nickname(authorizedNickname)
+                .build();
+
+        //when
+        ExtractableResponse<Response> response = checkNicknameDuplicateRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body().jsonPath().getBoolean("checkNickname")).isEqualTo(false);
+    }
+
+    /*
+        개인 정보 관리 테스트
+     */
+    @Test
+    @Order(13)
+    @DisplayName("회원 정보 수정 실패 [400]; 선택할 수 없는 성별 값(잘못된 형식)")
+    public void 개인_정보_관리_실패_BAD_REQUEST_1() throws Exception {
         // given
         String accessToken = authorizedLogin();
         MemberUpdateRequest request = MemberUpdateRequest.builder()
                 .gender(null)
                 .dateOfBirth(LocalDateTime.now().toLocalDate())
-                .password(changedPassword)
-                .passwordCheck(changedPassword)
+                .nickname(notExistNickname)
                 .build();
 
         // when
@@ -260,32 +317,13 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 10: 회원 정보 수정 실패 [400]; 비밀번호와 비밀번호 문자열이 다름")
-    public void 회원정보_수정_실패_BAD_REQUEST_2() throws Exception {
+    @Order(14)
+    @DisplayName("회원 정보 수정 실패 [400]; 일부 정보만 주었을 때")
+    public void 개인정보_관리_실패_BAD_REQUEST_2() throws Exception {
         // given
         String accessToken = authorizedLogin();
         MemberUpdateRequest request = MemberUpdateRequest.builder()
-                .gender(Gender.HIDDEN)
-                .password(changedPassword)
-                .passwordCheck(MemberDataLoader.wrongPassword)
-                .dateOfBirth(LocalDateTime.now().toLocalDate())
-                .build();
-
-        // when
-        ExtractableResponse<Response> response = memberUpdateRequest(accessToken, request);
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
-
-    @Test
-    @DisplayName("테스트 11: 회원 정보 수정 실패 [400]; 일부 정보만 주었을 때")
-    public void 회원정보_수정_성공_BAD_REQUEST_3() throws Exception {
-        // given
-        String accessToken = authorizedLogin();
-        MemberUpdateRequest request = MemberUpdateRequest.builder()
-                .password(MemberDataLoader.password)
-                .passwordCheck(MemberDataLoader.password)
+                .nickname(notExistNickname)
                 .build();
 
         // when
@@ -300,14 +338,14 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 12: 회원 정보 수정 실패 [403]; 로그인하지 않았을 때")
-    public void 회원정보_수정_실패_FORBIDDEN() throws Exception {
+    @Order(15)
+    @DisplayName("회원 정보 수정 실패 [403]; 로그인하지 않았을 때")
+    public void 개인정보_관리_실패_FORBIDDEN() throws Exception {
         // given
         String accessToken = "";
         MemberUpdateRequest request = MemberUpdateRequest.builder()
                 .dateOfBirth(LocalDateTime.now().toLocalDate())
-                .password(changedPassword)
-                .passwordCheck(changedPassword)
+                .nickname(notExistNickname)
                 .gender(Gender.HIDDEN)
                 .build();
 
@@ -319,14 +357,33 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 13: 회원 정보 수정 성공 [200]; 모든 정보를 주었을 때")
-    @Rollback
-    public void 회원정보_수정_성공_OK() throws Exception {
+    @Order(16)
+    @DisplayName("회원 정보 수정 실패 [409]; 이미 존재하는 닉네임일 때")
+    public void 개인정보_관리_실패_CONFLICT() throws Exception {
         // given
         String accessToken = authorizedLogin();
         MemberUpdateRequest request = MemberUpdateRequest.builder()
-                .password(changedPassword)
-                .passwordCheck(changedPassword)
+                .gender(Gender.HIDDEN)
+                .nickname(authorizedNickname)
+                .dateOfBirth(LocalDateTime.now().toLocalDate())
+                .build();
+
+        // when
+        ExtractableResponse<Response> response = memberUpdateRequest(accessToken, request);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    @Test
+    @Order(17)
+    @DisplayName("회원 정보 수정 성공 [200]; 모든 정보를 주었을 때")
+    @Rollback
+    public void 개인정보_관리_성공_OK() throws Exception {
+        // given
+        String accessToken = authorizedLogin();
+        MemberUpdateRequest request = MemberUpdateRequest.builder()
+                .nickname(notExistNickname)
                 .gender(Gender.HIDDEN)
                 .dateOfBirth(LocalDateTime.now().toLocalDate())
                 .build();
@@ -345,22 +402,136 @@ public class MemberApiTest extends AcceptanceTest {
 //        assertThat(user.getDateOfBirth()).isEqualTo(now);
 
         // rollback
-        String rollbackAccessToken = changedAuthorizedLogin();
         MemberUpdateRequest rollbackRequest = MemberUpdateRequest.builder()
-                .password(MemberDataLoader.password)
-                .passwordCheck(MemberDataLoader.password)
+                .nickname(authorizedNickname)
                 .gender(Gender.HIDDEN)
                 .dateOfBirth(LocalDateTime.now().toLocalDate())
                 .build();
 
-        memberUpdateRequest(rollbackAccessToken, rollbackRequest);
+        memberUpdateRequest(accessToken, rollbackRequest);
+    }
+
+    /*
+        현재 비밀번호 확인
+     */
+    @Test
+    @Order(18)
+    @DisplayName("현재 비밀번호 확인 실패 [400]; 비밀번호 입력이 없을 때")
+    public void 현재_비밀번호_확인_실패_BAD_REQUEST() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        PasswordCheckRequest request = PasswordCheckRequest.builder().build();
+
+        //when
+        ExtractableResponse<Response> response = checkPasswordRightRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @Order(19)
+    @DisplayName("현재 비밀번호 확인 성공 [200]; 비밀번호 맞았을 때 checkPassword true로 반환")
+    public void 현재_비밀번호_확인_성공_OK_1() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        PasswordCheckRequest request = PasswordCheckRequest.builder()
+                .password(password)
+                .build();
+
+        //when
+        ExtractableResponse<Response> response = checkPasswordRightRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body().jsonPath().getBoolean("checkPassword")).isEqualTo(true);
+    }
+
+    @Test
+    @Order(20)
+    @DisplayName("현재 비밀번호 확인 성공 [200]; 비밀번호 입력이 틀렸을 때 checkPassword false로 반환")
+    public void 현재_비밀번호_확인_성공_OK_2() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        PasswordCheckRequest request = PasswordCheckRequest.builder()
+                .password(wrongPassword)
+                .build();
+
+        //when
+        ExtractableResponse<Response> response = checkPasswordRightRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body().jsonPath().getBoolean("checkPassword")).isEqualTo(false);
+    }
+
+    /*
+        비밀 변경 테스트
+     */
+
+    @Test
+    @Order(21)
+    @DisplayName("비밀번호 변경 실패 [400]; 비밀번호가 공백으로 왔을 때")
+    public void 비밀번호_변경_실패_BAD_REQUEST_1() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        PasswordUpdateRequest request = PasswordUpdateRequest.builder().build();
+
+        //when
+        ExtractableResponse<Response> response = updatePasswordRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @Order(22)
+    @DisplayName("비밀번호 변경 실패 [400]; 비밀번호와 비밀번호 확인이 다를 때")
+    public void 비밀번호_변경_실패_BAD_REQUEST_2() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        PasswordUpdateRequest request = PasswordUpdateRequest.builder()
+                .password(changedPassword)
+                .passwordCheck(wrongPassword)
+                .build();
+
+        //when
+        ExtractableResponse<Response> response = updatePasswordRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @Order(23)
+    @DisplayName("비밀번호 변경 성공 [200]")
+    public void 비밀번호_변경_성공_OK() throws Exception {
+        //given
+        String accessToken = authorizedLogin();
+        PasswordUpdateRequest request = PasswordUpdateRequest.builder()
+                .password(changedPassword)
+                .passwordCheck(changedPassword)
+                .build();
+
+        //when
+        ExtractableResponse<Response> response = updatePasswordRequest(accessToken, request);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+
+        PasswordUpdateRequest rollbackRequest = PasswordUpdateRequest.builder()
+                .password(password)
+                .passwordCheck(password)
+                .build();
+        updatePasswordRequest(accessToken, rollbackRequest);
     }
 
     /*
         회원 팔로우/언팔로우 테스트
      */
     @Test
-    @DisplayName("테스트 14: 회원 팔로우 실패 [403]; 로그인하지 않음")
+    @Order(24)
+    @DisplayName("회원 팔로우 실패 [403]; 로그인하지 않음")
     public void 회원_팔로우_실패_FORBIDDEN_1() throws Exception {
         // given
         String accessToken = "";
@@ -373,7 +544,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 15: 회원 팔로우 실패 [403]; 이메일 인증하지 않음")
+    @Order(25)
+    @DisplayName("회원 팔로우 실패 [403]; 이메일 인증하지 않음")
     public void 회원_팔로우_실패_FORBIDDEN_2() throws Exception {
         // given
         String accessToken = unauthorizedLogin();
@@ -386,7 +558,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 16: 회원 팔로우 실패 [404]; 해당 nickname 의 회원이 존재하지 않음")
+    @Order(26)
+    @DisplayName("회원 팔로우 실패 [404]; 해당 nickname 의 회원이 존재하지 않음")
     public void 회원_팔로우_실패_NOT_FOUND() throws Exception {
         // given
         String accessToken = authorizedLogin();
@@ -399,7 +572,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 17: 회원 팔로우 실패 [409]; 해당 nickname 의 회원이 팔로우 신청할 수 없는 대상일 때")
+    @Order(27)
+    @DisplayName("회원 팔로우 실패 [409]; 해당 nickname 의 회원이 팔로우 신청할 수 없는 대상일 때")
     public void 회원_팔로우_실패_CONFLICT_1() throws Exception {
         // given
         String accessToken = authorizedLogin();
@@ -412,7 +586,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 18: 회원 팔로우 실패 [409]; 해당 nickname 의 회원이 자신일 때")
+    @Order(28)
+    @DisplayName("회원 팔로우 실패 [409]; 해당 nickname 의 회원이 자신일 때")
     public void 회원_팔로우_실패_CONFLICT_2() throws Exception {
         // given
         String accessToken = authorizedLogin();
@@ -425,7 +600,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 19: 회원 팔로우 성공 [200]; Unfollowed -> Following")
+    @Order(29)
+    @DisplayName("회원 팔로우 성공 [200]; Unfollowed -> Following")
     public void 회원_팔로우_성공_OK_1() throws Exception {
         // given
         String accessToken = authorizedLogin();
@@ -455,7 +631,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 20: 회원 언팔로우 성공 [200]; Followed -> Unfollowing")
+    @Order(30)
+    @DisplayName("회원 언팔로우 성공 [200]; Followed -> Unfollowing")
     public void 회원_팔로우_성공_OK_2() throws Exception {
         // given
         String accessToken = authorizedLogin();
@@ -488,7 +665,8 @@ public class MemberApiTest extends AcceptanceTest {
         회원 탈퇴 테스트
      */
     @Test
-    @DisplayName("테스트 21: 회원 탈퇴 실패 [403]; 로그인하지 않음.")
+    @Order(31)
+    @DisplayName("회원 탈퇴 실패 [403]; 로그인하지 않음.")
     public void 회원_탈퇴_실패_FORBIDDEN_1() throws Exception {
         // given
         String accessToken = "";
@@ -501,7 +679,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 22: 회원 탈퇴 실패 [403]; 본인도 아니고, 관리자도 아님")
+    @Order(32)
+    @DisplayName("회원 탈퇴 실패 [403]; 본인도 아니고, 관리자도 아님")
     public void 회원_탈퇴_실패_FORBIDDEN_2() throws Exception {
         // given
         String accessToken = unauthorizedLogin();
@@ -514,7 +693,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 23: 회원 탈퇴 실패 [404]; 해당하는 회원이 없음")
+    @Order(33)
+    @DisplayName("회원 탈퇴 실패 [404]; 해당하는 회원이 없음")
     public void 회원_탈퇴_실패_NOT_FOUND() throws Exception {
         // given
         String accessToken = authorizedLogin();
@@ -527,7 +707,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 24: 회원 탈퇴 성공 [200]; 본인일 때")
+    @Order(34)
+    @DisplayName("회원 탈퇴 성공 [200]; 본인일 때")
     public void 회원_탈퇴_성공_OK_1() throws Exception {
         // given
         String accessToken = unauthorizedLogin();
@@ -544,7 +725,8 @@ public class MemberApiTest extends AcceptanceTest {
     }
 
     @Test
-    @DisplayName("테스트 25: 회원 탈퇴 성공 [200]; 관리자일 때")
+    @Order(35)
+    @DisplayName("회원 탈퇴 성공 [200]; 관리자일 때")
     public void 회원_탈퇴_성공_OK_2() throws Exception {
         // given
         String accessToken = adminLogin();
@@ -560,7 +742,7 @@ public class MemberApiTest extends AcceptanceTest {
 //        assertThat(expelledMember.getRoles().hasRole(MemberRole.EXPELLED)).isTrue();
     }
 
-    private static ExtractableResponse<Response> memberCreateRequest(MemberCreateRequest request) {
+    private ExtractableResponse<Response> memberCreateRequest(MemberCreateRequest request) {
         return RestAssured
                 .given().log().all()
                 .body(request)
@@ -570,7 +752,18 @@ public class MemberApiTest extends AcceptanceTest {
                 .extract();
     }
 
-    private static ExtractableResponse<Response> memberUpdateRequest(String accessToken, MemberUpdateRequest request) {
+    private ExtractableResponse<Response> checkNicknameDuplicateRequest(String accessToken, NicknameCheckRequest request) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .body(request)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when().get("/members/nickname")
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> memberUpdateRequest(String accessToken, MemberUpdateRequest request) {
         return RestAssured
                 .given().log().all()
                 .auth().oauth2(accessToken)
@@ -581,7 +774,29 @@ public class MemberApiTest extends AcceptanceTest {
                 .extract();
     }
 
-    private static ExtractableResponse<Response> memberFollowRequest(
+    private ExtractableResponse<Response> checkPasswordRightRequest(String accessToken, PasswordCheckRequest request) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .body(request)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when().get("/members/password")
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> updatePasswordRequest(String accessToken, PasswordUpdateRequest request) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .body(request)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when().put("/members/password")
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> memberFollowRequest(
             String accessToken, String nickname
     ) {
         return RestAssured
@@ -592,7 +807,7 @@ public class MemberApiTest extends AcceptanceTest {
                 .extract();
     }
 
-    private static ExtractableResponse<Response> memberWithdrawalRequest(String accessToken, String nickname) {
+    private ExtractableResponse<Response> memberWithdrawalRequest(String accessToken, String nickname) {
         return RestAssured
                 .given().log().all()
                 .auth().oauth2(accessToken)
@@ -601,18 +816,7 @@ public class MemberApiTest extends AcceptanceTest {
                 .extract();
     }
 
-    private static String changedAuthorizedLogin() {
-        LoginRequest request = LoginRequest.builder()
-                .email(MemberDataLoader.authorizedEmail)
-                .password(changedPassword)
-                .build();
-
-        return loginRequest(request)
-                .as(LoginResponse.class)
-                .getAccessToken();
-    }
-
-    private static String adminLogin() {
+    private String adminLogin() {
         LoginRequest request = LoginRequest.builder()
                 .email(MemberDataLoader.adminEmail)
                 .password(MemberDataLoader.password)

--- a/src/test/java/com/emotie/api/member/MemberAcceptanceTest.java
+++ b/src/test/java/com/emotie/api/member/MemberAcceptanceTest.java
@@ -517,7 +517,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = updatePasswordRequest(accessToken, request);
 
         //then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
 
         PasswordUpdateRequest rollbackRequest = PasswordUpdateRequest.builder()
                 .password(password)

--- a/src/test/java/com/emotie/api/member/MemberDataLoader.java
+++ b/src/test/java/com/emotie/api/member/MemberDataLoader.java
@@ -37,6 +37,7 @@ public class MemberDataLoader implements CommandLineRunner {
 
     public static String authorizationToken = "authorization_token", passwordResetToken = "password_reset_token";
 
+    public static String authorizedNickname = "authorizedNickname";
     private String introduction = "안녕하세요";
 
     @Override
@@ -45,7 +46,7 @@ public class MemberDataLoader implements CommandLineRunner {
                 Member.builder()
                         .UUID(UUID.randomUUID().toString())
                         .email(authorizedEmail)
-                        .nickname(authorizedEmail)
+                        .nickname(authorizedNickname)
                         .passwordHash(passwordHashProvider.encodePassword(password))
                         .gender(Gender.HIDDEN)
                         .dateOfBirth(LocalDate.now())


### PR DESCRIPTION
8/28 회의 이후 api 명세서 변경으로 인한  수정
- 회원 api 명세서의 닉네임 중복 확인, 개인정보 관리(회원 정보 수정에서 스펙이 달라짐), 현재 비밀번호 확인 (비밀번호 변경시), 비밀번호 변경 api를 추가 했습니다.
- 테스트 코드 order 하는 방법을 다르게 했습니다. Test XX: 이렇게 있는 거는 어떻게 보면 비효율적이라고 생각이 됩니다.
- 그리고 주석 같은 것은 최대한 지워주시는 게 나을 거 같습니다.
- 이것도 최종본이 아니라 리펙토링을 진행해야 할 거 같습니다.